### PR TITLE
fix: ensure uv pip install uses venv instead of --system flag

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -8,13 +8,13 @@ npm = "latest"
 uv_venv_auto = "create|source"
 
 [env]
-_.python.venv = { path = ".venv", create = true, uv_create_args = ['--seed'] }
+_.python.venv = { path = ".venv", create = true, uv_create_args = ["--seed"] }
 
 [tasks]
 # Install all dependencies (backend + frontend)
 install = { run = """
 echo "Installing backend dependencies..."
-uv pip install -r requirements.txt --system
+uv pip install -r requirements.txt
 echo "Installing frontend dependencies..."
 cd admin-dashboard && npm install
 echo "All dependencies installed successfully!"
@@ -40,7 +40,7 @@ echo "All linters passed!"
 # Run development server
 dev = { run = """
 echo "Starting Flask development server..."
-python app.py
+.venv/bin/python app.py
 """, description = "Run development server" }
 
 # Run frontend development server
@@ -96,3 +96,4 @@ mise run lint
 mise run test
 mise run build
 """, description = "Run full CI pipeline (lint + test + build)" }
+


### PR DESCRIPTION
## Summary
This PR fixes the mise.toml configuration to properly use the virtual environment for Python dependencies.

## Changes
- Removed `--system` flag from install task so `uv pip install` installs to .venv
- Updated dev task to explicitly use `.venv/bin/python`

## Testing
- ✅ `mise run install` successfully installs Flask and dependencies to .venv
- ✅ Flask is now available in the venv (verified with `.venv/bin/python -c 'import flask'`)
- ✅ `mise run dev` now uses the venv Python

## Context
Previously, `mise run dev` was failing because Flask wasn't found - the --system flag was installing dependencies to the system Python instead of the virtual environment.