### PR TITLE
fix: Add missing OIDCProvider(app) instantiation

### DIFF
--- a/app.py
+++ b/app.py
@@ -61,6 +61,7 @@ migrate = Migrate(app, db)
 limiter = init_security(app)
 
 # Initialise OIDC provider (for acting as OIDC server)
+oidc = OIDCProvider(app)
 
 # Register a demo OIDC client (for testing/development)
 oidc.register_client(


### PR DESCRIPTION
Bug: Line was accidentally removed during merge conflict resolution\nImpact: App failed to start with NameError: name oidc is not defined\nFix: Added oidc = OIDCProvider(app) after comment\n\nThis bug should have been caught by integration tests (now being created)