### PR TITLE
fix(ci): use ubuntu-latest for Docker builds

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-push-image:
-    runs-on: readreceipt
+    runs-on: ubuntu-latest
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
## Problem

The Docker build job fails on the self-hosted `readreceipt` runner because Docker daemon isn't running:

```
ERROR: failed to connect to the docker API at unix:///var/run/docker.sock
dial unix /var/run/docker.sock: connect: no such file or directory
```

## Solution

Change the `build-and-publish.yml` workflow to use `ubuntu-latest` (GitHub-hosted runner) instead of the self-hosted `readreceipt` runner.

GitHub-hosted runners have Docker pre-installed and running, ensuring reliable builds.

## Testing

This will be tested automatically when the PR is merged and the workflow runs.

Closes #137 (if applicable)